### PR TITLE
Added timestamp ex; buildPaket() typo; uniform object's member names

### DIFF
--- a/BTHome/BTHome.cpp
+++ b/BTHome/BTHome.cpp
@@ -8,14 +8,13 @@
 static BLEAdvertising *pAdvertising;    // From NimBLE : BLEAdvertising = NimBLEAdvertising
 
 // Note: the BTHome class is declared in the header file
-
 void BTHome::begin(String dname, bool encryption, String key, bool trigger_based_device) {
   /*
     The 'begin' method of the BTHome class, used where a String encryption key is provided
   */
   uint8_t bind_key[BIND_KEY_LEN];
   for (uint8_t i = 0; i < BIND_KEY_LEN; i++) {
-    bind_key[i] = strtol(key.substring(i * 2, i * 2 + 2).c_str(), NULL, BIND_KEY_BASE);
+    bind_key[i] = strtol(key.substring(i * 2, i * 2 + 2).c_str(), NULL, 16);
   }
   begin(dname, encryption, bind_key, trigger_based_device);
 }

--- a/BTHome/BTHome.cpp
+++ b/BTHome/BTHome.cpp
@@ -40,9 +40,9 @@ void BTHome::begin(String dname, bool encryption, uint8_t const* const key, bool
     #else
       this->m_encryptCount = random(0, UINT32_MAX) % 0x427;
     #endif
-    memcpy(bindKey, key, sizeof(uint8_t) * BIND_KEY_LEN);
+    memcpy(m_bindKey, key, sizeof(uint8_t) * BIND_KEY_LEN);
     mbedtls_ccm_init(&this->m_encryptCTX);
-    mbedtls_ccm_setkey(&this->m_encryptCTX, MBEDTLS_CIPHER_ID_AES, bindKey, BIND_KEY_LEN * 8);
+    mbedtls_ccm_setkey(&this->m_encryptCTX, MBEDTLS_CIPHER_ID_AES, m_bindKey, BIND_KEY_LEN * 8);
   } else {
     this->m_encryptEnable = false;
   }
@@ -53,12 +53,12 @@ void BTHome::begin(String dname, bool encryption, uint8_t const* const key, bool
 
 void BTHome::setDeviceName(String dname) {
   if (!dname.isEmpty())
-    this->dev_name = dname;
+    this->m_devName = dname;
 }
 
 void BTHome::resetMeasurement() {
   this->m_sensorDataIdx = 0;
-  this->last_object_id = 0;
+  this->m_lastObjectId = 0;
   this->m_sortEnable = false;
 }
 
@@ -73,9 +73,9 @@ void BTHome::addMeasurement_state(uint8_t sensor_id, uint8_t state, uint8_t step
       this->m_sensorDataIdx++;
     }
     if (!this->m_sortEnable) {
-      if (sensor_id < this->last_object_id) this->m_sortEnable = true;
+      if (sensor_id < this->m_lastObjectId) this->m_sortEnable = true;
     }
-    last_object_id = sensor_id;
+    m_lastObjectId = sensor_id;
   }
   else {
     sendPacket();
@@ -95,9 +95,9 @@ void BTHome::addMeasurement(uint8_t sensor_id, uint64_t value) {
       this->m_sensorDataIdx++;
     }
     if (!this->m_sortEnable) {
-      if (sensor_id < this->last_object_id) this->m_sortEnable = true;
+      if (sensor_id < this->m_lastObjectId) this->m_sortEnable = true;
     }
-    last_object_id = sensor_id;
+    m_lastObjectId = sensor_id;
   }
   else {
     sendPacket();
@@ -118,9 +118,9 @@ void BTHome::addMeasurement(uint8_t sensor_id, float value) {
       this->m_sensorDataIdx++;
     }
     if (!this->m_sortEnable) {
-      if (sensor_id < this->last_object_id) this->m_sortEnable = true;
+      if (sensor_id < this->m_lastObjectId) this->m_sortEnable = true;
     }
-    last_object_id = sensor_id;
+    m_lastObjectId = sensor_id;
   }
   else {
     sendPacket();
@@ -144,9 +144,9 @@ void BTHome::addMeasurement(uint8_t sensor_id, uint8_t *value, uint8_t size) {
       this->m_sensorDataIdx++;
     }
     if (!this->m_sortEnable) {
-      if (sensor_id < this->last_object_id) this->m_sortEnable = true;
+      if (sensor_id < this->m_lastObjectId) this->m_sortEnable = true;
     }
-    last_object_id = sensor_id;
+    m_lastObjectId = sensor_id;
   }
   else {
     sendPacket();
@@ -321,10 +321,10 @@ void BTHome::buildPacket() {
   pAdvertising->setAdvertisementData(oAdvertisementData);
 
   //fill the local name into oScanResponseData
-  if (!this->dev_name.isEmpty()) {
-    int dn_length = this->dev_name.length() + 1;
+  if (!this->m_devName.isEmpty()) {
+    int dn_length = this->m_devName.length() + 1;
     if (dn_length > 28) dn_length = 28;//BLE_ADVERT_MAX_LEN - FLAG = 31 - 3
-    oScanResponseData.setName(this->dev_name.substring(0, dn_length - 1).c_str());
+    oScanResponseData.setName(this->m_devName.substring(0, dn_length - 1).c_str());
   }
   pAdvertising->setScanResponseData(oScanResponseData);
 
@@ -415,6 +415,7 @@ uint8_t BTHome::getByteNumber(uint8_t sens) {
     case ID_GAS4:
     case ID_VOLUME:
     case ID_WATER:
+    case ID_TIMESTAMP:
       return 4; break;
     default:
       return 2;

--- a/BTHome/BTHome.cpp
+++ b/BTHome/BTHome.cpp
@@ -5,7 +5,7 @@
 #include <NimBLEDevice.h>   // v2.x
 #include "BTHome.h"
 
-static BLEAdvertising *pAdvertising;    // From NimBLE
+static BLEAdvertising *pAdvertising;    // From NimBLE : BLEAdvertising = NimBLEAdvertising
 
 // Note: the BTHome class is declared in the header file
 
@@ -47,13 +47,14 @@ void BTHome::begin(String dname, bool encryption, uint8_t const* const key, bool
     this->m_encryptEnable = false;
   }
 
-  this->m_triggerdevice = trigger_based_device;
+  this->m_triggerDevice = trigger_based_device;
   resetMeasurement();
 }
 
 void BTHome::setDeviceName(String dname) {
-  if (!dname.isEmpty())
+  if (!dname.isEmpty()) {
     this->m_devName = dname;
+  }
 }
 
 void BTHome::resetMeasurement() {
@@ -73,11 +74,12 @@ void BTHome::addMeasurement_state(uint8_t sensor_id, uint8_t state, uint8_t step
       this->m_sensorDataIdx++;
     }
     if (!this->m_sortEnable) {
-      if (sensor_id < this->m_lastObjectId) this->m_sortEnable = true;
+      if (sensor_id < this->m_lastObjectId) {
+        this->m_sortEnable = true;
+      }
     }
     m_lastObjectId = sensor_id;
-  }
-  else {
+  } else {
     sendPacket();
     addMeasurement_state(sensor_id, state, steps);
   }
@@ -89,17 +91,17 @@ void BTHome::addMeasurement(uint8_t sensor_id, uint64_t value) {
   if ((this->m_sensorDataIdx + size + 1) <= (MEASUREMENT_MAX_LEN - (this->m_encryptEnable ? 8 : 0))) {
     this->m_sensorData[this->m_sensorDataIdx] = static_cast<byte>(sensor_id & 0xff);
     this->m_sensorDataIdx++;
-    for (uint8_t i = 0; i < size; i++)
-    {
+    for (uint8_t i = 0; i < size; i++) {
       this->m_sensorData[this->m_sensorDataIdx] = static_cast<byte>(((value * factor) >> (8 * i)) & 0xff);
       this->m_sensorDataIdx++;
     }
     if (!this->m_sortEnable) {
-      if (sensor_id < this->m_lastObjectId) this->m_sortEnable = true;
+      if (sensor_id < this->m_lastObjectId) {
+        this->m_sortEnable = true;
+      }
     }
     m_lastObjectId = sensor_id;
-  }
-  else {
+  } else {
     sendPacket();
     addMeasurement(sensor_id, value);
   }
@@ -112,17 +114,17 @@ void BTHome::addMeasurement(uint8_t sensor_id, float value) {
     uint64_t value2 = static_cast<uint64_t>(value * factor);
     this->m_sensorData[this->m_sensorDataIdx] = static_cast<byte>(sensor_id & 0xff);
     this->m_sensorDataIdx++;
-    for (uint8_t i = 0; i < size; i++)
-    {
+    for (uint8_t i = 0; i < size; i++) {
       this->m_sensorData[this->m_sensorDataIdx] = static_cast<byte>((value2 >> (8 * i)) & 0xff);
       this->m_sensorDataIdx++;
     }
     if (!this->m_sortEnable) {
-      if (sensor_id < this->m_lastObjectId) this->m_sortEnable = true;
+      if (sensor_id < this->m_lastObjectId) {
+        this->m_sortEnable = true;
+      }
     }
     m_lastObjectId = sensor_id;
-  }
-  else {
+  } else {
     sendPacket();
     addMeasurement(sensor_id, value);
   }
@@ -138,17 +140,17 @@ void BTHome::addMeasurement(uint8_t sensor_id, uint8_t *value, uint8_t size) {
     this->m_sensorData[this->m_sensorDataIdx] = static_cast<byte>(size & 0xff);
     this->m_sensorDataIdx++;
     // Add data bytes
-    for (uint8_t i = 0; i < size; i++)
-    {
+    for (uint8_t i = 0; i < size; i++) {
       this->m_sensorData[this->m_sensorDataIdx] = static_cast<byte>(value[i] & 0xff);
       this->m_sensorDataIdx++;
     }
     if (!this->m_sortEnable) {
-      if (sensor_id < this->m_lastObjectId) this->m_sortEnable = true;
+      if (sensor_id < this->m_lastObjectId) {
+        this->m_sortEnable = true;
+      }
     }
     m_lastObjectId = sensor_id;
-  }
-  else {
+  } else {
     sendPacket();
     addMeasurement(sensor_id, value, size);
   }
@@ -172,12 +174,12 @@ void BTHome::sortSensorData() {
     data_block_num++;
     //copy the data length
     if (this->m_sensorData[j] == EVENT_DIMMER) {
-      if (this->m_sensorData[j + 1] == EVENT_DIMMER_NONE)
+      if (this->m_sensorData[j + 1] == EVENT_DIMMER_NONE) {
         data_block[i].data_len = 1;
-      else
+      } else {
         data_block[i].data_len = 2;
-    }
-    else {
+      }
+    } else {
       data_block[i].data_len = getByteNumber(this->m_sensorData[j]);
     }
     //copy the data
@@ -214,7 +216,9 @@ void BTHome::buildPacket() {
   //the Object ids have to be applied in numerical order (from low to high)
   Serial.println("Building the BTHome packet...");
 
-  if (this->m_sortEnable) sortSensorData();
+  if (this->m_sortEnable) {
+    sortSensorData();
+  }
 
   // Create the BLE Device
   BLEAdvertisementData oAdvertisementData = BLEAdvertisementData();
@@ -259,10 +263,11 @@ void BTHome::buildPacket() {
 
   // The encryption
   if (this->m_encryptEnable) {
-    if (this->m_triggerdevice)
+    if (this->m_triggerDevice) {
       serviceData += ENCRYPT_TRIGGER_BASE;
-    else
+    } else {
       serviceData += ENCRYPT;
+    }
     uint8_t ciphertext[BLE_ADVERT_MAX_LEN];
     uint8_t encryptionTag[MIC_LEN];
     //buildNonce
@@ -285,8 +290,7 @@ void BTHome::buildPacket() {
     mbedtls_ccm_encrypt_and_tag(&this->m_encryptCTX, this->m_sensorDataIdx, nonce, NONCE_LEN, 0, 0,
                                 &this->m_sensorData[0], &ciphertext[0], encryptionTag,
                                 MIC_LEN);
-    for (i = 0; i < this->m_sensorDataIdx; i++)
-    {
+    for (i = 0; i < this->m_sensorDataIdx; i++) {
       serviceData += ciphertext[i];
     }
     //writeCounter
@@ -300,14 +304,13 @@ void BTHome::buildPacket() {
     serviceData += encryptionTag[1];
     serviceData += encryptionTag[2];
     serviceData += encryptionTag[3];
-  }
-  else {
-    if (this->m_triggerdevice)
+  } else {
+    if (this->m_triggerDevice) {
       serviceData += NO_ENCRYPT_TRIGGER_BASE;
-    else
+    } else {
       serviceData += NO_ENCRYPT;
-    for (i = 0; i < this->m_sensorDataIdx; i++)
-    {
+    }
+    for (i = 0; i < this->m_sensorDataIdx; i++) {
       serviceData += this->m_sensorData[i]; // Add the sensor data to the Service Data
     }
   }
@@ -323,7 +326,9 @@ void BTHome::buildPacket() {
   //fill the local name into oScanResponseData
   if (!this->m_devName.isEmpty()) {
     int dn_length = this->m_devName.length() + 1;
-    if (dn_length > 28) dn_length = 28;//BLE_ADVERT_MAX_LEN - FLAG = 31 - 3
+    if (dn_length > 28) {  //BLE_ADVERT_MAX_LEN - FLAG = 31 - 3
+      dn_length = 28;
+    }
     oScanResponseData.setName(this->m_devName.substring(0, dn_length - 1).c_str());
   }
   pAdvertising->setScanResponseData(oScanResponseData);
@@ -355,7 +360,7 @@ void BTHome::sendPacket(uint32_t delay_ms) {
   */
   if (this->m_sensorDataIdx > 0) {
     buildPacket();
-    if (!isAdvertising()){
+    if (!isAdvertising()) {
       // Start advertising
       start();
     } 

--- a/BTHome/BTHome.cpp
+++ b/BTHome/BTHome.cpp
@@ -15,7 +15,7 @@ void BTHome::begin(String dname, bool encryption, String key, bool trigger_based
   */
   uint8_t bind_key[BIND_KEY_LEN];
   for (uint8_t i = 0; i < BIND_KEY_LEN; i++) {
-    bind_key[i] = strtol(key.substring(i * 2, i * 2 + 2).c_str(), NULL, BIND_KEY_LEN);
+    bind_key[i] = strtol(key.substring(i * 2, i * 2 + 2).c_str(), NULL, BIND_KEY_BASE);
   }
   begin(dname, encryption, bind_key, trigger_based_device);
 }

--- a/BTHome/BTHome.h
+++ b/BTHome/BTHome.h
@@ -1,3 +1,5 @@
+#ifndef BTHOME_H
+#define BTHOME_H
 /*
   BTHome Header file
 
@@ -159,3 +161,4 @@ class BTHome {
     bool m_sortEnable;
     byte m_lastObjectId;
 };
+#endif // BTHOME_H

--- a/BTHome/BTHome.h
+++ b/BTHome/BTHome.h
@@ -15,7 +15,7 @@
 #define NONCE_LEN 13
 #define MIC_LEN 4
 
-//https://bthome.io/format/
+// https://bthome.io/format/
 // Advertising Data (AD) elements
 // Each element contains the following:
 //    1st byte: length of the element (excluding the length byte itself)
@@ -152,7 +152,7 @@ class BTHome {
     void sortSensorData();
     String m_devName;
     bool m_encryptEnable;
-    bool m_triggerdevice;
+    bool m_triggerDevice;
     uint32_t m_encryptCount;
     mbedtls_ccm_context m_encryptCTX;
     uint8_t m_bindKey[BIND_KEY_LEN];

--- a/BTHome/BTHome.h
+++ b/BTHome/BTHome.h
@@ -78,6 +78,7 @@
 #define ID_VOLUMEFR 0x49
 #define ID_UV 0x46
 #define ID_WATER 0x4F
+#define ID_TIMESTAMP 0x50
 #define ID_TEXT 0x53
 #define ID_RAW 0x54
 
@@ -149,12 +150,12 @@ class BTHome {
     uint8_t m_sensorDataIdx;
     byte m_sensorData[MEASUREMENT_MAX_LEN] = {0};
     void sortSensorData();
-    String dev_name;
+    String m_devName;
     bool m_encryptEnable;
     bool m_triggerdevice;
     uint32_t m_encryptCount;
     mbedtls_ccm_context m_encryptCTX;
-    uint8_t bindKey[BIND_KEY_LEN];
+    uint8_t m_bindKey[BIND_KEY_LEN];
     bool m_sortEnable;
-    byte last_object_id;
+    byte m_lastObjectId;
 };

--- a/BTHome/BTHome.h
+++ b/BTHome/BTHome.h
@@ -14,7 +14,6 @@
 #define BLE_ADVERT_MAX_LEN 31
 #define MEASUREMENT_MAX_LEN 23 //23=31(BLE_ADVERT_MAX_LEN)-3(FLAG)-1(SERVICE_DATA)-2(UUID)-1(ENCRYPT)-1(serviceData length bit)
 #define BIND_KEY_LEN 16   // stabilisce la lunghezza dell’array bind_key[]
-#define BIND_KEY_BASE 16  // fissa su hex la base dei valori da salvare in BIND_KEY
 #define NONCE_LEN 13
 #define MIC_LEN 4
 

--- a/BTHome/BTHome.h
+++ b/BTHome/BTHome.h
@@ -13,7 +13,8 @@
 
 #define BLE_ADVERT_MAX_LEN 31
 #define MEASUREMENT_MAX_LEN 23 //23=31(BLE_ADVERT_MAX_LEN)-3(FLAG)-1(SERVICE_DATA)-2(UUID)-1(ENCRYPT)-1(serviceData length bit)
-#define BIND_KEY_LEN 16
+#define BIND_KEY_LEN 16   // stabilisce la lunghezza della bind key
+#define BIND_KEY_BASE 16  // stabilisce la base hex della stringa della bind key
 #define NONCE_LEN 13
 #define MIC_LEN 4
 

--- a/BTHome/BTHome.h
+++ b/BTHome/BTHome.h
@@ -13,8 +13,8 @@
 
 #define BLE_ADVERT_MAX_LEN 31
 #define MEASUREMENT_MAX_LEN 23 //23=31(BLE_ADVERT_MAX_LEN)-3(FLAG)-1(SERVICE_DATA)-2(UUID)-1(ENCRYPT)-1(serviceData length bit)
-#define BIND_KEY_LEN 16   // stabilisce la lunghezza della bind key
-#define BIND_KEY_BASE 16  // stabilisce la base hex della stringa della bind key
+#define BIND_KEY_LEN 16   // stabilisce la lunghezza dell’array bind_key[]
+#define BIND_KEY_BASE 16  // fissa su hex la base dei valori da salvare in BIND_KEY
 #define NONCE_LEN 13
 #define MIC_LEN 4
 

--- a/BTHome/BTHome.ino
+++ b/BTHome/BTHome.ino
@@ -51,6 +51,9 @@ void loop() {
   bthome.addMeasurement_state(EVENT_BUTTON, EVENT_BUTTON_PRESS);//2 button press
   bthome.addMeasurement_state(EVENT_DIMMER, EVENT_DIMMER_RIGHT, 6); //3, rotate right 6 steps
 
+  // Timestamp data, represented as UTC epoch
+  bthome.addMeasurement(ID_TIMESTAMP, (uint64_t)1738797643);
+
   // TEXT data
   String msg = "Sensor XYZ";
   bthome.addMeasurement(ID_TEXT, (uint8_t *)msg.c_str(), msg.length());
@@ -68,7 +71,7 @@ void loop() {
   bthome.addMeasurement(ID_HUMIDITY_PRECISE, 70.00f);//3
   bthome.addMeasurement(ID_PRESSURE, 1000.86f);//4
   bthome.addMeasurement(ID_ILLUMINANCE, 1008.81f);//4 bytes
-  bthome.buildPaket();
+  bthome.buildPacket();
   bthome.start();//start the first adv data
   delay(1500);
 
@@ -78,7 +81,7 @@ void loop() {
   bthome.addMeasurement(ID_TVOC, (uint64_t)220);//3
   bthome.addMeasurement_state(EVENT_BUTTON, EVENT_BUTTON_PRESS);//2, button press
   bthome.addMeasurement_state(EVENT_DIMMER, EVENT_DIMMER_RIGHT, 6); //3, rotate right 6 steps
-  bthome.buildPaket();//change the adv data
+  bthome.buildPacket();//change the adv data
   delay(1500);
   bthome.stop();
 

--- a/BTHome/BTHome.ino
+++ b/BTHome/BTHome.ino
@@ -17,7 +17,9 @@
 
 // Change the bind key any string of 32 hex characters (a-f, 0-9).
 // The Home Assistant BTHome integration will autodiscover your device and will ask you to enter this bind key.
-String BIND_KEY = "431d39c1d7cc1ac1aef224cd096db934"; 
+String BIND_KEY = "431d39c1d7cc1ac1aef224cd096db934";  // consider defining it as const object, to be tested.
+// Consider renaming it ENCRYPTION_KEY like BTHome does:
+// const String ENCRYPTION_KEY = "431d39c1d7cc1ac1aef224cd096db934";
 
 // Create a global instance of the BTHome class
 BTHome bthome;


### PR DESCRIPTION
- added timestamp measurement example (as suggested elsewhere by @onliner10 )
- buildPaket() corrected to buildPacket()
- uniform BTHome object's member naming convention (e.g. m_devName instead of dev_name)